### PR TITLE
Use the remote chain to help encode the transaction

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,5 +4,5 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   roots: ["./src"],
-  testTimeout: 2_000,
+  testTimeout: 4_000,
 };

--- a/src/referendum-tx.ts
+++ b/src/referendum-tx.ts
@@ -1,18 +1,7 @@
-/**
- * We're using the fact that Kusama has the fellowshipReferenda pallet,
- * so the types are available there.
- * Polkadot has that pallet on a Collectives parachain,
- * and it's not available in that types.
- */
-import "@polkadot/api-augment/kusama";
-import { ApiPromise } from "@polkadot/api";
+import { ApiPromise, WsProvider } from "@polkadot/api";
 
 import { byteSize, hashProposal } from "./util";
 
-/**
- * The URL is not used by the bot to connect to the chain.
- * It is only used to construct a link to Polkadot.js.org/apps that will be able to decode the transaction.
- */
 const PROVIDER_URL = "wss://polkadot-collectives-rpc.polkadot.io";
 const POLKADOT_APPS_URL = `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(PROVIDER_URL)}#/`;
 const polkadotAppsDecodeURL = (transactionHex: string) => `${POLKADOT_APPS_URL}extrinsics/decode/${transactionHex}`;
@@ -21,7 +10,7 @@ export const createReferendumTx = async (opts: {
   rfcNumber: string;
   rfcProposalText: string;
 }): Promise<{ transactionHex: string; transactionCreationUrl: string; remarkText: string }> => {
-  const api = new ApiPromise();
+  const api = new ApiPromise({ provider: new WsProvider(PROVIDER_URL) });
   await api.isReadyOrError;
 
   const remarkText = `RFC_APPROVE(${opts.rfcNumber},${hashProposal(opts.rfcProposalText)})`;
@@ -33,15 +22,12 @@ export const createReferendumTx = async (opts: {
   }
 
   const submitTx = api.tx.fellowshipReferenda.submit(
-    { Origins: "Fellows" },
+    { FellowshipOrigins: "Fellows" },
     { Inline: remarkTx.method.toHex() },
     { After: 0 },
   );
 
-  let transactionHex: string = submitTx.method.toHex();
-  // Replace the positions of Kusama indexes to Polkadot's Collectives
-  transactionHex = transactionHex.replace("1700", "3d00"); // fellowshipReferenda.submit call index
-  transactionHex = transactionHex.replace("2b0f", "3e01"); // {Origins: 'Fellows'} changed to {FellowshipOrigins: 'Fellows'}
+  const transactionHex: string = submitTx.method.toHex();
 
   await api.disconnect();
   return { transactionHex, transactionCreationUrl: polkadotAppsDecodeURL(transactionHex), remarkText };


### PR DESCRIPTION
Turns out that I was wrong about how the transaction encoding worked.

1. The `@polkadot/api-augment/*` augmentation are only about typescript typechecking, they do not impact transaction encoding at all.
2. I thought that my code worked offline but it's not true. I had a local Kusama running on `localhost:9944` and turns out that the api was connecting to it by default. Now it connects to Collectives, and turns out that it automatically reads what's necessary and can encode the transaction without any monkey hacks.