### PR TITLE
Comment out the staging deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,13 +163,13 @@ publish-docker-image-description:
         $CI_PROJECT_NAME helm/
     - kubectl get pods -n ${CI_PROJECT_NAME}
 
-deploy-stg:
-  stage:                           staging
-  <<:                              *deploy-k8s
-  <<:                              *kubernetes-env
-  <<:                              *publish-deploy-stg-refs
-  variables:
-    CI_IMAGE:                      "paritytech/kubetools:3.5.3"
-    ENVIRONMENT:                   parity-stg
-  tags:
-    - rfc-bot-stg
+# deploy-stg:
+#   stage:                           staging
+#   <<:                              *deploy-k8s
+#   <<:                              *kubernetes-env
+#   <<:                              *publish-deploy-stg-refs
+#   variables:
+#     CI_IMAGE:                      "paritytech/kubetools:3.5.3"
+#     ENVIRONMENT:                   parity-stg
+#   tags:
+#     - rfc-bot-stg

--- a/helm/values-parity-stg.yaml
+++ b/helm/values-parity-stg.yaml
@@ -1,29 +1,29 @@
-common:
-  env:
-    APP_HOST: "https://rfc-bot.parity-stg.parity.io"
-    MATRIX_SERVER_URL: "https://m.parity.io"
-    MATRIX_ROOM_ID: "!KiTmXyGkdiLNzrzMgj:parity.io" # ENG: Engineering Automation -> Bot Test Farm
-  secrets:
-    # WEBHOOK_SECRET is used internally by probot: https://probot.github.io/docs/configuration/
-    WEBHOOK_SECRET: ref+vault://kv/gitlab/parity/mirrors/rfc-bot/opstooling-parity-stg#WEBHOOK_SECRET
-    PRIVATE_KEY: ref+vault://kv/gitlab/parity/mirrors/rfc-bot/opstooling-parity-stg#PRIVATE_KEY
-    APP_ID: ref+vault://kv/gitlab/parity/mirrors/rfc-bot/opstooling-parity-stg#APP_ID
-    MATRIX_ACCESS_TOKEN: ref+vault://kv/gitlab/parity/mirrors/rfc-bot/opstooling-parity-stg#MATRIX_ACCESS_TOKEN
-  ingress:
-    annotations:
-      external-dns.alpha.kubernetes.io/target: traefik-external.parity-stg.parity.io.
-    rules:
-      - host: rfc-bot.parity-stg.parity.io
-        http:
-          paths:
-            - path: /
-              pathType: ImplementationSpecific
-              backend:
-                service:
-                  name: rfc-bot
-                  port:
-                    name: http
-    tls:
-      - hosts:
-          - rfc-bot.parity-stg.parity.io
-        secretName: rfc-bot.parity-stg.parity.io
+# common:
+#   env:
+#     APP_HOST: "https://rfc-bot.parity-stg.parity.io"
+#     MATRIX_SERVER_URL: "https://m.parity.io"
+#     MATRIX_ROOM_ID: "!KiTmXyGkdiLNzrzMgj:parity.io" # ENG: Engineering Automation -> Bot Test Farm
+#   secrets:
+#     # WEBHOOK_SECRET is used internally by probot: https://probot.github.io/docs/configuration/
+#     WEBHOOK_SECRET: ref+vault://kv/gitlab/parity/mirrors/rfc-bot/opstooling-parity-stg#WEBHOOK_SECRET
+#     PRIVATE_KEY: ref+vault://kv/gitlab/parity/mirrors/rfc-bot/opstooling-parity-stg#PRIVATE_KEY
+#     APP_ID: ref+vault://kv/gitlab/parity/mirrors/rfc-bot/opstooling-parity-stg#APP_ID
+#     MATRIX_ACCESS_TOKEN: ref+vault://kv/gitlab/parity/mirrors/rfc-bot/opstooling-parity-stg#MATRIX_ACCESS_TOKEN
+#   ingress:
+#     annotations:
+#       external-dns.alpha.kubernetes.io/target: traefik-external.parity-stg.parity.io.
+#     rules:
+#       - host: rfc-bot.parity-stg.parity.io
+#         http:
+#           paths:
+#             - path: /
+#               pathType: ImplementationSpecific
+#               backend:
+#                 service:
+#                   name: rfc-bot
+#                   port:
+#                     name: http
+#     tls:
+#       - hosts:
+#           - rfc-bot.parity-stg.parity.io
+#         secretName: rfc-bot.parity-stg.parity.io


### PR DESCRIPTION
This repo has been superseded by the [rfc-action](https://github.com/paritytech/rfc-action).

Therefore this rfc-bot is obsolete, and we can remove the staging deployment of it in order to save resources.